### PR TITLE
Add calender to permission scope

### DIFF
--- a/pages/test_login.js
+++ b/pages/test_login.js
@@ -15,6 +15,7 @@ export default function Home() {
   const [signupOrLogin, setSignupOrLogin] = useState(null);
 
   const googleLogin = useGoogleLogin({
+    scope: 'https://www.googleapis.com/auth/calendar',
     onSuccess: async ({ code }) => {
       try {
         const tokens = await axios.post('/api/auth/google', { code });


### PR DESCRIPTION
Adds calendar to permissions during google login. Will need to test with some logins